### PR TITLE
Fixed SaveAnywhere Compatibility for SaveAnywhere 3.2.6

### DIFF
--- a/FarmTypeManager/Events/Compatibility/SaveAnywhere/EnableSaveAnywhere.cs
+++ b/FarmTypeManager/Events/Compatibility/SaveAnywhere/EnableSaveAnywhere.cs
@@ -25,13 +25,12 @@ namespace FarmTypeManager
             {
                 Utility.Monitor.Log("Save Anywhere API loaded. Sending compatibility events.", LogLevel.Trace);
                 saveAnywhere.addBeforeSaveEvent(ModManifest.UniqueID, SaveAnywhere_BeforeSave);
-                /*
-                 * disable "aftersave" due to the current version of SaveAnywhere not executing it; a workaround has been added below
-                 * 
                 saveAnywhere.addAfterSaveEvent(ModManifest.UniqueID, SaveAnywhere_AfterSave);
-                */
 
-                Utility.Helper.Events.Display.MenuChanged += SaveAnywhere_MenuChanged;
+                /*
+                 * workaround shouldn't work in SaveAnywhere 3.2.6+ as it switched to using the normal SaveGameMenu
+                 Utility.Helper.Events.Display.MenuChanged += SaveAnywhere_MenuChanged;
+                */
             }
         }
 


### PR DESCRIPTION
SaveAnywhere Switched to use the normal SaveGameMenu in 3.2.6 and fixed AfterSave not executing