### PR TITLE
Improved QuickSave compatibility

### DIFF
--- a/FarmTypeManager/API/Implementation/LoadFarmDataForApi.cs
+++ b/FarmTypeManager/API/Implementation/LoadFarmDataForApi.cs
@@ -56,12 +56,12 @@ namespace FarmTypeManager
                         //attempt to load the save data for this pack and specific farm
                         try
                         {
-                            save = pack.ReadJsonFile<InternalSaveData>($"data/{Constants.SaveFolderName}_SaveData.save"); //load the content pack's save data for this farm (null if it doesn't exist)
+                            save = pack.ReadJsonFile<InternalSaveData>($"data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"); //load the content pack's save data for this farm (null if it doesn't exist)
                         }
                         catch (Exception ex)
                         {
                             Monitor.Log($"Warning: Your farm's save data for this content pack could not be parsed correctly: {pack.Manifest.Name}", LogLevel.Warn);
-                            Monitor.Log($"This file will need to be edited or deleted: data/{Constants.SaveFolderName}_SaveData.save", LogLevel.Warn);
+                            Monitor.Log($"This file will need to be edited or deleted: data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save", LogLevel.Warn);
                             Monitor.Log($"The content pack will be skipped until this issue is fixed. The auto-generated error message is displayed below:", LogLevel.Warn);
                             Monitor.Log($"----------", LogLevel.Warn);
                             Monitor.Log($"{ex.Message}", LogLevel.Warn);
@@ -76,7 +76,7 @@ namespace FarmTypeManager
                         ValidateFarmData(config, pack); //validate certain data in the current file before using it
 
                         pack.WriteJsonFile($"content.json", config); //update the content pack's config file
-                        pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save"), save); //create or update the content pack's save file for the current farm
+                        pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"), save); //create or update the content pack's save file for the current farm
 
                         list.Add(new FarmData(config, save, pack)); //add the config, save, and content pack to the farm data list
                         Monitor.Log("Content pack loaded successfully.", LogLevel.Trace);

--- a/FarmTypeManager/Events/DayStarted.cs
+++ b/FarmTypeManager/Events/DayStarted.cs
@@ -36,7 +36,7 @@ namespace FarmTypeManager
                 }
                 else //this data is from this mod's own folders
                 {
-                    Utility.Monitor.VerboseLog($"Checking objects from FarmTypeManager/data/{Constants.SaveFolderName}_SaveData.save");
+                    Utility.Monitor.VerboseLog($"Checking objects from FarmTypeManager/data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save");
                 }
 
                 Utility.ReplaceProtectedSpawns(data.Save); //protect unexpired spawns listed in the save data
@@ -49,7 +49,7 @@ namespace FarmTypeManager
             Generation.MonsterGeneration();
 
             Utility.StartOfDay = Game1.timeOfDay; //record the current time of day (in case other mods have changed this)
-            if (Utility.StartOfDay.Time == 600) //if the current time of day is 6:00AM, as expected
+            if (Utility.StartOfDay.Time == 600 && !QuickSaveIsLoading) //if the current time of day is 6:00AM, as expected
             {
                 Generation.SpawnTimedSpawns(Utility.TimedSpawns, 600); //spawn anything set to appear at this time
             }

--- a/FarmTypeManager/Events/Saved.cs
+++ b/FarmTypeManager/Events/Saved.cs
@@ -33,7 +33,7 @@ namespace FarmTypeManager
                 }
                 else //this data is from this mod's own folders
                 {
-                    Utility.Monitor.VerboseLog($"Checking objects from FarmTypeManager/data/{Constants.SaveFolderName}_SaveData.save");
+                    Utility.Monitor.VerboseLog($"Checking objects from FarmTypeManager/data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save");
                 }
 
                 Utility.ReplaceProtectedSpawns(data.Save); //protect unexpired spawns listed in the save data

--- a/FarmTypeManager/Events/Saving.cs
+++ b/FarmTypeManager/Events/Saving.cs
@@ -35,18 +35,18 @@ namespace FarmTypeManager
                 }
                 else //this data is from this mod's own folders
                 {
-                    Utility.Monitor.VerboseLog($"Processing save data for FarmTypeManager/data/{Constants.SaveFolderName}_SaveData.save");
+                    Utility.Monitor.VerboseLog($"Processing save data for FarmTypeManager/data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save");
                 }
 
                 Utility.ProcessObjectExpiration(save: data.Save, endOfDay: false); //remove custom object classes, but do not process expiration settings
 
                 if (data.Pack != null) //if this data is from a content pack
                 {
-                    data.Pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save"), data.Save); //update the save file for that content pack
+                    data.Pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"), data.Save); //update the save file for that content pack
                 }
                 else //this data is from this mod's own folders
                 {
-                    Helper.Data.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save"), data.Save); //update the save file in this mod's own folders
+                    Helper.Data.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"), data.Save); //update the save file in this mod's own folders
                 }
             }
         }

--- a/FarmTypeManager/Utility/Loading/LoadFarmData.cs
+++ b/FarmTypeManager/Utility/Loading/LoadFarmData.cs
@@ -56,12 +56,12 @@ namespace FarmTypeManager
                         //attempt to load the save data for this pack and specific farm
                         try
                         {
-                            save = pack.ReadJsonFile<InternalSaveData>($"data/{Constants.SaveFolderName}_SaveData.save"); //load the content pack's save data for this farm (null if it doesn't exist)
+                            save = pack.ReadJsonFile<InternalSaveData>($"data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"); //load the content pack's save data for this farm (null if it doesn't exist)
                         }
                         catch (Exception ex)
                         {
                             Monitor.Log($"Warning: Your farm's save data for this content pack could not be parsed correctly: {pack.Manifest.Name}", LogLevel.Warn);
-                            Monitor.Log($"This file will need to be edited or deleted: data/{Constants.SaveFolderName}_SaveData.save", LogLevel.Warn);
+                            Monitor.Log($"This file will need to be edited or deleted: data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save", LogLevel.Warn);
                             Monitor.Log($"The content pack will be skipped until this issue is fixed. The auto-generated error message is displayed below:", LogLevel.Warn);
                             Monitor.Log($"----------", LogLevel.Warn);
                             Monitor.Log($"{ex.Message}", LogLevel.Warn);
@@ -76,7 +76,7 @@ namespace FarmTypeManager
                         ValidateFarmData(config, pack); //validate certain data in the current file before using it
 
                         pack.WriteJsonFile($"content.json", config); //update the content pack's config file
-                        pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save"), save); //create or update the content pack's save file for the current farm
+                        pack.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"), save); //create or update the content pack's save file for the current farm
 
                         if (CheckFileConditions(config, pack)) //check file conditions; only use the current data if this returns true
                         {
@@ -144,11 +144,11 @@ namespace FarmTypeManager
                 //attempt to load the save data for this farm
                 try
                 {
-                    save = Helper.Data.ReadJsonFile<InternalSaveData>(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save")); //load the mod's save data for this farm (null if it doesn't exist)
+                    save = Helper.Data.ReadJsonFile<InternalSaveData>(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save")); //load the mod's save data for this farm (null if it doesn't exist)
                 }
                 catch (Exception ex)
                 {
-                    Monitor.Log($"Warning: This file could not be parsed correctly: FarmTypeManager/data/{Constants.SaveFolderName}_SaveData.save", LogLevel.Warn);
+                    Monitor.Log($"Warning: This file could not be parsed correctly: FarmTypeManager/data/{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save", LogLevel.Warn);
                     Monitor.Log($"Please edit the file, or delete it and reload your farm to generate a new savedata file.", LogLevel.Warn);
                     Monitor.Log($"Your config file will be skipped until this issue is fixed. The auto-generated error message is displayed below:", LogLevel.Warn);
                     Monitor.Log($"----------", LogLevel.Warn);
@@ -164,7 +164,7 @@ namespace FarmTypeManager
                 ValidateFarmData(config, null); //validate certain data in the current file before using it
 
                 Helper.Data.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}.json"), config); //create or update the config file for the current farm
-                Helper.Data.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}_SaveData.save"), save); //create or update this config's save file for the current farm
+                Helper.Data.WriteJsonFile(Path.Combine("data", $"{Constants.SaveFolderName}{QSSaveFileSuffix}_SaveData.save"), save); //create or update this config's save file for the current farm
 
                 if (CheckFileConditions(config, null)) //check file conditions; only use the current data if this returns true
                 {

--- a/FarmTypeManager/Utility/Spawning/Forage/ParseSavedObjectsFromItemList.cs
+++ b/FarmTypeManager/Utility/Spawning/Forage/ParseSavedObjectsFromItemList.cs
@@ -42,8 +42,13 @@ namespace FarmTypeManager
                         ConfigItem item = null;
                         try
                         {
-                            item = rawObj.ToObject<ConfigItem>(); //attempt to parse this into a ConfigItem
-                            saved = CreateSavedObject(item, areaID); //use the item to create a saved object
+                            if(rawObj.ContainsKey("ConfigItem")) { //rawObj should already be a SavedObject
+                                saved = rawObj.ToObject<SavedObject>();
+                            } else {
+                                item = rawObj.ToObject<ConfigItem>(); //attempt to parse this into a ConfigItem
+                                saved = CreateSavedObject(item, areaID); //use the item to create a saved object
+                            }
+
                         }
                         catch
                         {
@@ -82,7 +87,8 @@ namespace FarmTypeManager
                     {
                         Type = SavedObject.ObjectType.Object,
                         Name = objectName,
-                        StringID = objectID
+                        StringID = objectID,
+                        ConfigItem = new ConfigItem() { Category = "object" }
                     };
                     Monitor.VerboseLog($"Parsed \"{objectName}\" into object ID: {objectID}");
                     return saved;


### PR DESCRIPTION
Hello!
Hope you're having a nice day.
This PR aims to improve quicksaving behaviour for the mod [QuickSave](https://www.nexusmods.com/stardewvalley/mods/26194).

- **Save QS data in separate file**
Anytime QS is saving or loading the data/\*_SaveData.save will be appended by _QuickSave to data/\*_QuickSave_SaveData.save
Eg.
`data/DAW_390838504_SaveData`
`data/DAW_390838504_QuickSave_SaveData`
Serves to improve data consistency for quicksaves

- **Fixed monsters not being persisted correctly**
Monster loot is saved as SavedObject, but read as ConfigItem.
This causes a parsing issue when quicksaving, but presumably never caused issues before because monster data has an expiration date of 1d and gets removed at DayEnd.
ParseSavedObjectsFromItemList now also checks if the provided JObject has a "ConfigItem" property, in which case it is assumed to already be a SavedObject.
There's no cleaner way I can think of currently. Maybe you could add $type metadata when parsing or consistently use one or the other (or just keep as input string), but that'd be too invasive of a pr.
This was tested using loot as list of object ids, eg. "Loot": [ "Lumisteria.MtVapius_WeirdCoins" ]
(Specifically VMVs Lumisteria.MtVapius_ForestCaveStar location)
It'd perhaps be nice if the monster tile location and hp would be persisted as well in the future, but it should be good enough for now.

- **Improved DayStarted behaviour to prevent duplicate resource generation when quickloading**

- **Cleaned up QS compatibility class**

