### PR TITLE
Performance improvement suggestions

### DIFF
--- a/FarmTypeManager/Classes/ConfigItem.cs
+++ b/FarmTypeManager/Classes/ConfigItem.cs
@@ -90,6 +90,26 @@ namespace FarmTypeManager
             {
 
             }
+
+            /// <summary>Creates a deep copy of this ConfigItem. Faster alternative to JSON-based cloning.</summary>
+            /// <returns>A new ConfigItem with identical property values.</returns>
+            public ConfigItem DeepCopy()
+            {
+                ConfigItem copy = new()
+                {
+                    CanBePickedUp = CanBePickedUp,
+                    Category = Category,
+                    IsOn = IsOn,
+                    Name = Name,
+                    PercentChanceToSpawn = PercentChanceToSpawn,
+                    Rotation = Rotation,
+                    SpawnWeight = SpawnWeight,
+                    Stack = Stack
+                };
+                if (Contents != null)
+                    copy.Contents = [.. Contents]; //shallow copy of the list; elements are JObjects/primitives that are not mutated after deserialization
+                return copy;
+            }
         }
     }
 }

--- a/FarmTypeManager/Classes/MonsterType.cs
+++ b/FarmTypeManager/Classes/MonsterType.cs
@@ -58,6 +58,16 @@ namespace FarmTypeManager
                 MonsterName = monsterName;
                 Settings = settings;
             }
+
+            /// <summary>Creates a deep copy of this MonsterType. Faster alternative to JSON-based cloning.</summary>
+            /// <returns>A new MonsterType with identical property values.</returns>
+            public MonsterType DeepCopy()
+            {
+                MonsterType copy = new MonsterType();
+                copy.MonsterName = this.MonsterName;
+                copy.settings = new Dictionary<string, object>(this.settings, StringComparer.OrdinalIgnoreCase); //copy dictionary directly to backing field, preserving case-insensitive comparer
+                return copy;
+            }
         }
     }
 }

--- a/FarmTypeManager/Classes/MonsterType.cs
+++ b/FarmTypeManager/Classes/MonsterType.cs
@@ -63,9 +63,11 @@ namespace FarmTypeManager
             /// <returns>A new MonsterType with identical property values.</returns>
             public MonsterType DeepCopy()
             {
-                MonsterType copy = new MonsterType();
-                copy.MonsterName = this.MonsterName;
-                copy.settings = new Dictionary<string, object>(this.settings, StringComparer.OrdinalIgnoreCase); //copy dictionary directly to backing field, preserving case-insensitive comparer
+                MonsterType copy = new()
+                {
+                    MonsterName = MonsterName,
+                    settings = new Dictionary<string, object>(settings, StringComparer.OrdinalIgnoreCase) //copy dictionary directly to backing field, preserving case-insensitive comparer
+                };
                 return copy;
             }
         }

--- a/FarmTypeManager/Classes/SavedObject.cs
+++ b/FarmTypeManager/Classes/SavedObject.cs
@@ -187,6 +187,23 @@ namespace FarmTypeManager
             public SavedObject()
             {
             }
+
+            /// <summary>Creates a deep copy of this SavedObject. Faster alternative to JSON-based cloning.</summary>
+            /// <returns>A new SavedObject with identical property values.</returns>
+            public SavedObject DeepCopy()
+            {
+                SavedObject copy = new SavedObject();
+                copy.MapName = this.MapName;
+                copy.Name = this.Name;
+                copy.Tile = this.Tile; //Vector2 is a value type
+                copy.Type = this.Type; //enum is a value type
+                copy.ID = this.ID; //null, boxed int, or string (immutable) -- safe to share reference
+                copy.DaysUntilExpire = this.DaysUntilExpire;
+                copy.SpawnTime = this.SpawnTime; //StardewTime is a struct (value type)
+                copy.ConfigItem = this.ConfigItem?.DeepCopy();
+                copy.MonType = this.MonType?.DeepCopy();
+                return copy;
+            }
         }
     }
 }

--- a/FarmTypeManager/Classes/SavedObject.cs
+++ b/FarmTypeManager/Classes/SavedObject.cs
@@ -192,16 +192,18 @@ namespace FarmTypeManager
             /// <returns>A new SavedObject with identical property values.</returns>
             public SavedObject DeepCopy()
             {
-                SavedObject copy = new SavedObject();
-                copy.MapName = this.MapName;
-                copy.Name = this.Name;
-                copy.Tile = this.Tile; //Vector2 is a value type
-                copy.Type = this.Type; //enum is a value type
-                copy.ID = this.ID; //null, boxed int, or string (immutable) -- safe to share reference
-                copy.DaysUntilExpire = this.DaysUntilExpire;
-                copy.SpawnTime = this.SpawnTime; //StardewTime is a struct (value type)
-                copy.ConfigItem = this.ConfigItem?.DeepCopy();
-                copy.MonType = this.MonType?.DeepCopy();
+                SavedObject copy = new()
+                {
+                    MapName = MapName,
+                    Name = Name,
+                    Tile = Tile, //Vector2 is a value type
+                    Type = Type, //enum is a value type
+                    ID = ID, //null, boxed int, or string (immutable) -- safe to share reference
+                    DaysUntilExpire = DaysUntilExpire,
+                    SpawnTime = SpawnTime, //StardewTime is a struct (value type)
+                    ConfigItem = ConfigItem?.DeepCopy(),
+                    MonType = MonType?.DeepCopy()
+                };
                 return copy;
             }
         }

--- a/FarmTypeManager/Classes/TileValidator.cs
+++ b/FarmTypeManager/Classes/TileValidator.cs
@@ -44,6 +44,9 @@ namespace FarmTypeManager
 
                 for (int index = 0; index < TileList.Count; index++) //for each listed tile
                 {
+                    if (InvalidTiles.Contains(TileList[index])) //skip tiles already known to be invalid
+                        continue;
+
                     bool allTilesValid = true;
 
                     //for each tile necessary for the given size
@@ -55,12 +58,7 @@ namespace FarmTypeManager
 
                             if (InvalidTiles.Contains(tileToCheck) || !Utility.IsTileValid(Location, tileToCheck, new Point(1, 1), StrictTileChecking)) //if the tile being checked is NOT valid
                             {
-                                int indexOfInvalidTile = TileList.IndexOf(tileToCheck); //get this invalid tile's index in the tile list (-1 if it's not in the list)
-                                if (indexOfInvalidTile >= 0 && indexOfInvalidTile <= index) //if the invalid tile is in the list, before/at the current index
-                                    index--; //decrement by 1 before removal, to avoid looping errors
-
-                                TileList.Remove(tileToCheck); //remove the tile from the list, if it was present
-                                InvalidTiles.Add(tileToCheck); //add the tile to the "invalid tiles" list
+                                InvalidTiles.Add(tileToCheck); //add the tile to the "invalid tiles" set
 
                                 allTilesValid = false;
                                 break; //skip the rest of the "y" loop
@@ -79,10 +77,6 @@ namespace FarmTypeManager
                         TileList.RemoveAt(index);
 
                         return finalTile;
-                    }
-                    else //if a tile was invalid
-                    {
-                        continue; //skip to the next tile index
                     }
                 }
 

--- a/FarmTypeManager/Generation Routines/ForageGeneration.cs
+++ b/FarmTypeManager/Generation Routines/ForageGeneration.cs
@@ -142,14 +142,6 @@ namespace FarmTypeManager
                                 {
                                     spawnCount--;
 
-                                    //get the total spawn weight of available forage types
-                                    int totalWeight = 0;
-
-                                    foreach (SavedObject obj in forageObjects) //for each object in the forage list
-                                    {
-                                        totalWeight += obj.ConfigItem?.SpawnWeight ?? 1; //increment total weight by this object's spawn weight (default 1)
-                                    }
-
                                     //select a random forage type
                                     SavedObject randomForage = null;
 
@@ -182,7 +174,7 @@ namespace FarmTypeManager
                                         Name = randomForage.Name,
                                         ID = randomForage.ID,
                                         DaysUntilExpire = area.DaysUntilSpawnsExpire,
-                                        ConfigItem = Utility.Clone(randomForage.ConfigItem) //use a separate copy of this
+                                        ConfigItem = randomForage.ConfigItem?.DeepCopy() //use a separate copy of this
                                     };
 
                                     //if this object has contents with spawn chances, process them

--- a/FarmTypeManager/Generation Routines/ForageGeneration.cs
+++ b/FarmTypeManager/Generation Routines/ForageGeneration.cs
@@ -130,6 +130,13 @@ namespace FarmTypeManager
                                 List<SavedObject> spawns = new List<SavedObject>(); //the list of objects to be spawned
                                 int skippedSpawns = 0; //the number of objects skipped due to their spawn chances
 
+                                //get the total spawn weight of available forage types
+                                int totalWeight = 0;
+                                foreach (SavedObject obj in forageObjects) //for each object in the forage list
+                                {
+                                    totalWeight += obj.ConfigItem?.SpawnWeight ?? 1; //increment total weight by this object's spawn weight (default 1)
+                                }
+
                                 //begin to generate forage
                                 while (spawnCount > 0) //while more forage should be spawned
                                 {

--- a/FarmTypeManager/Generation Routines/MonsterGeneration.cs
+++ b/FarmTypeManager/Generation Routines/MonsterGeneration.cs
@@ -74,24 +74,24 @@ namespace FarmTypeManager
 
                                 List<SavedObject> spawns = new List<SavedObject>(); //the list of objects to be spawned
 
+                                //get the total spawn weight of valid monster types
+                                int totalWeight = 0;
+                                foreach (MonsterType type in validMonsterTypes) //for each valid monster type
+                                {
+                                    if (type.Settings.ContainsKey("SpawnWeight")) //if a custom spawn weight was provided
+                                    {
+                                        totalWeight += Convert.ToInt32(type.Settings["SpawnWeight"]);
+                                    }
+                                    else //if no spawn weight was provided
+                                    {
+                                        totalWeight += 1;
+                                    }
+                                }
+
                                 //begin to generate monsters
                                 while (spawnCount > 0) //while more monsters should be spawned
                                 {
                                     spawnCount--;
-
-                                    //get the total spawn weight of valid monster types
-                                    int totalWeight = 0;
-                                    foreach (MonsterType type in validMonsterTypes) //for each valid monster type
-                                    {
-                                        if (type.Settings.ContainsKey("SpawnWeight")) //if a custom spawn weight was provided
-                                        {
-                                            totalWeight += Convert.ToInt32(type.Settings["SpawnWeight"]);
-                                        }
-                                        else //if no spawn weight was provided
-                                        {
-                                            totalWeight += 1;
-                                        }
-                                    }
 
                                     //select a random monster using spawn weights
                                     MonsterType randomMonster = null;
@@ -107,7 +107,7 @@ namespace FarmTypeManager
 
                                         if (random < spawnWeight) //if this monster type is selected
                                         {
-                                            randomMonster = Utility.Clone(validMonsterTypes[m]); //get the selected monster type (cloned for later use as a unique instance)
+                                            randomMonster = validMonsterTypes[m].DeepCopy(); //get the selected monster type (cloned for later use as a unique instance)
                                             break;
                                         }
                                         else //if this monster type is not selected

--- a/FarmTypeManager/Generation Routines/OreGeneration.cs
+++ b/FarmTypeManager/Generation Routines/OreGeneration.cs
@@ -92,17 +92,19 @@ namespace FarmTypeManager
 
                                 List<SavedObject> spawns = new List<SavedObject>(); //the list of objects to be spawned
 
+                                //get the total spawn weight of ore chances
+                                int totalWeight = 0; //the upper limit for the random number that picks ore type (i.e. the sum of all ore chances)
+                                foreach (KeyValuePair<string, int> ore in oreChances)
+                                {
+                                    totalWeight += ore.Value; //sum up all the ore chances
+                                }
+
                                 //begin to generate ore
                                 int randomOreNum;
                                 while (spawnCount > 0) //while more ore should be spawned
                                 {
                                     spawnCount--;
 
-                                    int totalWeight = 0; //the upper limit for the random number that picks ore type (i.e. the sum of all ore chances)
-                                    foreach (KeyValuePair<string, int> ore in oreChances)
-                                    {
-                                        totalWeight += ore.Value; //sum up all the ore chances
-                                    }
                                     randomOreNum = Utility.RNG.Next(totalWeight); //generate random number from 0 to [totalWeight - 1]
                                     foreach (KeyValuePair<string, int> ore in oreChances)
                                     {

--- a/FarmTypeManager/Generation Routines/SpawnTimedSpawns.cs
+++ b/FarmTypeManager/Generation Routines/SpawnTimedSpawns.cs
@@ -39,8 +39,16 @@ namespace FarmTypeManager
                         }
                         else //if a time was provided
                         {
-                            spawns = timedSpawns[x].Where(filter).ToList(); //get a list of spawns with matching times
-                            timedSpawns[x].RemoveAll(filter); //remove the matching spawns from the original list
+                            //collect matching spawns and remove them from the original list in a single pass
+                            spawns = new List<TimedSpawn>();
+                            for (int i = timedSpawns[x].Count - 1; i >= 0; i--)
+                            {
+                                if (filter(timedSpawns[x][i]))
+                                {
+                                    spawns.Add(timedSpawns[x][i]);
+                                    timedSpawns[x].RemoveAt(i);
+                                }
+                            }
 
                             if (timedSpawns[x].Count <= 0) //if the original list is now empty
                             {
@@ -101,7 +109,14 @@ namespace FarmTypeManager
 
                                 if (Utility.MConfig.MonsterLimitPerLocation.HasValue) //if a per-location monster limit was provided
                                 {
-                                    monstersAtLocation = location.characters.Count(character => character is Monster); //get the number of monsters at this location
+                                    //count monsters at this location
+                                    int monsterCount = 0;
+                                    foreach (var character in location.characters)
+                                    {
+                                        if (character is Monster)
+                                            monsterCount++;
+                                    }
+                                    monstersAtLocation = monsterCount;
                                 }
                                 break;
                         }
@@ -171,7 +186,7 @@ namespace FarmTypeManager
 
                                 if (spawns[y].SavedObject.DaysUntilExpire.HasValue) //if this object has an expiration date
                                 {
-                                    SavedObject saved = Utility.Clone(spawns[y].SavedObject); //clone this object to avoid any accidental modification
+                                    SavedObject saved = spawns[y].SavedObject.DeepCopy(); //clone this object to avoid any accidental modification
                                     spawns[y].FarmData.Save.SavedObjects.Add(saved); //add the spawn to the relevant save data
                                 }
                             }

--- a/FarmTypeManager/Utility/Spawning/Monsters/ApplyMonsterSettings.cs
+++ b/FarmTypeManager/Utility/Spawning/Monsters/ApplyMonsterSettings.cs
@@ -65,17 +65,19 @@ namespace FarmTypeManager
                     //parse the provided skill into an enum
                     Utility.Skills skill = (Utility.Skills)Enum.Parse(typeof(Utility.Skills), ((string)settings["RelatedSkill"]).Trim(), true); //parse while trimming whitespace and ignoring case
 
+                    //get highest skill level among all existing farmers once
+                    int highestSkillLevel = 0;
+                    foreach (Farmer farmer in Game1.getAllFarmers())
+                    {
+                        highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
+                    }
+
                     //multiply HP
                     if (settings.ContainsKey("PercentExtraHPPerSkillLevel"))
                     {
                         //calculate HP multiplier based on skill level
                         double skillMultiplier = Convert.ToInt32(settings["PercentExtraHPPerSkillLevel"]);
                         skillMultiplier = (skillMultiplier / 100); //converted to percent, e.g. "10" (10% per level) converts to "0.1"
-                        int highestSkillLevel = 0; //highest skill level among all existing farmers, not just the host
-                        foreach (Farmer farmer in Game1.getAllFarmers())
-                        {
-                            highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
-                        }
                         skillMultiplier = 1.0 + (skillMultiplier * highestSkillLevel); //final multiplier; e.g. if the setting is "10", this is "1.0" at level 0, "1.7" at level 7, etc
 
                         //apply the multiplier to the monster's max HP
@@ -89,11 +91,6 @@ namespace FarmTypeManager
                         //calculate damage multiplier based on skill level
                         double skillMultiplier = Convert.ToInt32(settings["PercentExtraDamagePerSkillLevel"]);
                         skillMultiplier = (skillMultiplier / 100); //converted to percent, e.g. "10" (10% per level) converts to "0.1"
-                        int highestSkillLevel = 0; //highest skill level among all existing farmers, not just the host
-                        foreach (Farmer farmer in Game1.getAllFarmers())
-                        {
-                            highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
-                        }
                         skillMultiplier = 1.0 + (skillMultiplier * highestSkillLevel); //final multiplier; e.g. if the setting is "10", this is "1.0" at level 0, "1.7" at level 7, etc
 
                         //apply the multiplier to the monster's damage
@@ -107,11 +104,6 @@ namespace FarmTypeManager
                         //calculate defense multiplier based on skill level
                         double skillMultiplier = Convert.ToInt32(settings["PercentExtraDefensePerSkillLevel"]);
                         skillMultiplier = (skillMultiplier / 100); //converted to percent, e.g. "10" (10% per level) converts to "0.1"
-                        int highestSkillLevel = 0; //highest skill level among all existing farmers, not just the host
-                        foreach (Farmer farmer in Game1.getAllFarmers())
-                        {
-                            highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
-                        }
                         skillMultiplier = 1.0 + (skillMultiplier * highestSkillLevel); //final multiplier; e.g. if the setting is "10", this is "1.0" at level 0, "1.7" at level 7, etc
 
                         //apply the multiplier to the monster's defense
@@ -125,11 +117,6 @@ namespace FarmTypeManager
                         //calculate dodge chance multiplier based on skill level
                         double skillMultiplier = Convert.ToInt32(settings["PercentExtraDodgeChancePerSkillLevel"]);
                         skillMultiplier = (skillMultiplier / 100); //converted to percent, e.g. "10" (10% per level) converts to "0.1"
-                        int highestSkillLevel = 0; //highest skill level among all existing farmers, not just the host
-                        foreach (Farmer farmer in Game1.getAllFarmers())
-                        {
-                            highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
-                        }
                         skillMultiplier = 1.0 + (skillMultiplier * highestSkillLevel); //final multiplier; e.g. if the setting is "10", this is "1.0" at level 0, "1.7" at level 7, etc
 
                         //apply the multiplier to the monster's dodge chance
@@ -143,11 +130,6 @@ namespace FarmTypeManager
                         //calculate exp multiplier based on skill level
                         double skillMultiplier = Convert.ToInt32(settings["PercentExtraEXPPerSkillLevel"]);
                         skillMultiplier = (skillMultiplier / 100); //converted to percent, e.g. "10" (10% per level) converts to "0.1"
-                        int highestSkillLevel = 0; //highest skill level among all existing farmers, not just the host
-                        foreach (Farmer farmer in Game1.getAllFarmers())
-                        {
-                            highestSkillLevel = Math.Max(highestSkillLevel, farmer.getEffectiveSkillLevel((int)skill)); //record the new level if it's higher than before
-                        }
                         skillMultiplier = 1.0 + (skillMultiplier * highestSkillLevel); //final multiplier; e.g. if the setting is "10", this is "1.0" at level 0, "1.7" at level 7, etc
 
                         //apply the multiplier to the monster's exp
@@ -159,7 +141,7 @@ namespace FarmTypeManager
                 //set loot (i.e. items dropped on death by the monster)
                 if (settings.ContainsKey("Loot"))
                 {
-                    List<SavedObject> loot = ((JArray)settings["Loot"]).ToObject<List<SavedObject>>(); //cast this list of saved objects (already validated and parsed elsewhere)
+                    List<SavedObject> loot = (List<SavedObject>)settings["Loot"]; //cast this list of saved objects (already validated and parsed in ValidateMonsterTypes)
                     MonsterTracker.SetLoot(monster, loot); //set the monster's loot in the monster tracker
                     monster.objectsToDrop.Clear(); //clear any "default" loot the monster might've had
                 }

--- a/FarmTypeManager/Utility/Spawning/Monsters/ValidateMonsterTypes.cs
+++ b/FarmTypeManager/Utility/Spawning/Monsters/ValidateMonsterTypes.cs
@@ -25,7 +25,11 @@ namespace FarmTypeManager
                     return new List<MonsterType>(); //return an empty list
                 }
 
-                List<MonsterType> validTypes = Clone(monsterTypes); //create a new copy of the list, to be validated and returned
+                List<MonsterType> validTypes = new List<MonsterType>(monsterTypes.Count); //create a new copy of the list, to be validated and returned
+                foreach (MonsterType type in monsterTypes)
+                {
+                    validTypes.Add(type.DeepCopy());
+                }
 
                 for (int x = validTypes.Count - 1; x >= 0; x--) //for each monster type in the new list (iterating backward to allow safe removal)
                 {

--- a/FarmTypeManager/Utility/Spawning/PopulateTimedSpawnList.cs
+++ b/FarmTypeManager/Utility/Spawning/PopulateTimedSpawnList.cs
@@ -17,32 +17,35 @@ namespace FarmTypeManager
             {
                 List<TimedSpawn> timedSpawns = new List<TimedSpawn>(); //the list of fully processed objects and associated data
 
-                Dictionary<int, int> possibleTimes = new Dictionary<int, int>(); //a dictionary of valid spawn times (keys) and the number of objects assigned to them (values)
+                List<int> possibleTimesList = new List<int>(); //a list of valid spawn times
+                Dictionary<int, int> timeCounts = new Dictionary<int, int>(); //tracks the number of objects assigned to each time
 
                 if (area.SpawnTiming == null) //if the SpawnTiming setting is null
                 {
-                    possibleTimes.Add(600, 0); //spawn everything at 6:00AM
+                    possibleTimesList.Add(600); //spawn everything at 6:00AM
+                    timeCounts[600] = 0;
                 }
                 else
                 {
                     for (StardewTime x = area.SpawnTiming.StartTime; x <= area.SpawnTiming.EndTime; x++) //for each 10-minute time from StartTime to EndTime
                     {
-                        possibleTimes.Add(x, 0); //add this time to the list
+                        possibleTimesList.Add(x); //add this time to the list
+                        timeCounts[x] = 0;
                     }
                 }
 
                 foreach (SavedObject obj in objects) //for each provided object
                 {
-                    int index = RNG.Next(0, possibleTimes.Count); //randomly select an index for a valid time
-                    obj.SpawnTime = possibleTimes.Keys.ElementAt(index); //assign the time to this object
+                    int index = RNG.Next(0, possibleTimesList.Count); //randomly select an index for a valid time
+                    obj.SpawnTime = possibleTimesList[index]; //assign the time to this object
                     timedSpawns.Add(new TimedSpawn(obj, data, area)); //add this object to the processed list
-                    possibleTimes[obj.SpawnTime]++; //increment the number of objects assigned to this time
+                    timeCounts[obj.SpawnTime]++; //increment the number of objects assigned to this time
 
-                    if (area.SpawnTiming.MaximumSimultaneousSpawns.HasValue && area.SpawnTiming.MaximumSimultaneousSpawns.Value <= possibleTimes[obj.SpawnTime]) //if "max spawns" exists and has been reached for this time
+                    if (area.SpawnTiming?.MaximumSimultaneousSpawns.HasValue == true && area.SpawnTiming.MaximumSimultaneousSpawns.Value <= timeCounts[obj.SpawnTime]) //if "max spawns" exists and has been reached for this time
                     {
-                        possibleTimes.Remove(obj.SpawnTime); //remove this time from the list
+                        possibleTimesList.RemoveAt(index); //remove this time from the list
                     }
-                    else if (area.SpawnTiming.MinimumTimeBetweenSpawns.HasValue && area.SpawnTiming.MinimumTimeBetweenSpawns.Value > 10) //if "time between" exists and is significant
+                    else if (area.SpawnTiming?.MinimumTimeBetweenSpawns.HasValue == true && area.SpawnTiming.MinimumTimeBetweenSpawns.Value > 10) //if "time between" exists and is significant
                     {
                         int between = (area.SpawnTiming.MinimumTimeBetweenSpawns.Value - 10) / 10; //get the number of other possible times to remove before/after the selected time
                         StardewTime minTime = obj.SpawnTime; //the earliest time to be removed from the list
@@ -54,17 +57,17 @@ namespace FarmTypeManager
                             maxTime++; //select the next time
                         }
 
-                        for (int x = possibleTimes.Count - 1; x >= 0; x--) //for each possible time (looping backward for removal purposes)
+                        for (int x = possibleTimesList.Count - 1; x >= 0; x--) //for each possible time (looping backward for removal purposes)
                         {
-                            int time = possibleTimes.Keys.ElementAt(x);
+                            int time = possibleTimesList[x];
                             if (time != obj.SpawnTime && time >= minTime && time <= maxTime) //if this time isn't the selected time, and is within the range of minTime and maxTime
                             {
-                                possibleTimes.Remove(time); //remove it from the list
+                                possibleTimesList.RemoveAt(x); //remove it from the list
                             }
                         }
                     }
 
-                    if (possibleTimes.Count <= 0) //if no valid spawn times are left
+                    if (possibleTimesList.Count <= 0) //if no valid spawn times are left
                     {
                         break; //skip the rest of the objects
                     }


### PR DESCRIPTION
For the past few weeks I have been playing a heavily modded version of Stardew. During that time I have been getting a lot of lag and hangs during the gameplay. FTM is not specifically responsible for these but I have been taking a look through the mods I have installed and identifying potential performance enhancements with the goal of trying to get my game running well.

The changes suggested here are intended mostly to reduce the computational complexity of operations in the mod to minimise unnecessary work and reduce garbage collection. Benchmarking these changes is difficult (or at least I am not aware of how) but I have been testing the changes in my instance as I go and noticing better performance. The changes in this PR primarilly reduce the day start hang that was becoming prevelant, combined with some changes to a few other mods that is mostly eliminated now for my instance.

I will add comments explaining the reason for the various changes, but here is a quick summary:

1. Eliminate JSON serialisation/deserialisation. These operations can be incredibly heavy especially with larger objects 
2. Reduce duplication of invariant calculations
3. Optimise tile validator to bail out sooner if tile is already known to be invalid
4. Add a 1x1 path for isValidTile that more efficiently checks when a tile is only 1x1. This seems to be 95%+ of the times it gets called
5. Switch populate time list to split the dictionary to have a list of times. This enables faster lookups when accessing the list

Feel free to cherry pick if not all of these are wanted